### PR TITLE
define a number of known methods on Mergent::Task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Define explicit methods in `Mergent::Task`, to allow for use of verifying doubles when testing against them.
+
 ## [0.1.0] - 2021-11-21
 
 - Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mergent (0.1.1)
+    mergent (0.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mergent (0.1.0)
+    mergent (0.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -73,4 +73,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.31
+   2.2.33

--- a/lib/mergent/task.rb
+++ b/lib/mergent/task.rb
@@ -9,5 +9,11 @@ module Mergent
       object = Client.post("tasks", params)
       new(object)
     end
+
+    %i[name description status request scheduled_for delay cron].each do |name|
+      define_method(name) do
+        self[name]
+      end
+    end
   end
 end

--- a/lib/mergent/version.rb
+++ b/lib/mergent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mergent
-  VERSION = "0.1.1"
+  VERSION = "0.1.0"
 end

--- a/lib/mergent/version.rb
+++ b/lib/mergent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mergent
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/mergent/task_spec.rb
+++ b/spec/mergent/task_spec.rb
@@ -23,4 +23,12 @@ RSpec.describe Mergent::Task do
       expect(task.name).to eq "taskname"
     end
   end
+
+  describe "delegated methods" do
+    %i[name description status request scheduled_for delay cron].each do |method_name|
+      it "defines a method for #{method_name}" do
+        expect(described_class.new(method_name => :foo).public_send(method_name)).to(eq(:foo))
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is simply to allow us to use verifying doubles when testing against gem-contributed modules and classes. Right now only Task has been updated, but others can be as necessary.