### PR TITLE
remove `cron` method definition

### DIFF
--- a/lib/mergent/task.rb
+++ b/lib/mergent/task.rb
@@ -10,7 +10,7 @@ module Mergent
       new(object)
     end
 
-    %i[name description status request scheduled_for delay cron].each do |name|
+    %i[name description status request scheduled_for delay].each do |name|
       define_method(name) do
         self[name]
       end

--- a/spec/mergent/task_spec.rb
+++ b/spec/mergent/task_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Mergent::Task do
   end
 
   describe "delegated methods" do
-    %i[name description status request scheduled_for delay cron].each do |method_name|
+    %i[name description status request scheduled_for delay].each do |method_name|
       it "defines a method for #{method_name}" do
         expect(described_class.new(method_name => :foo).public_send(method_name)).to(eq(:foo))
       end


### PR DESCRIPTION
This removes the `cron` method definition from Mergent::Task, as recurring Tasks are being redone in a different way, imminently.