### PR TITLE
Replace OpenStruct with Mergent::Object wrapped Hash

### DIFF
--- a/lib/mergent/client.rb
+++ b/lib/mergent/client.rb
@@ -20,7 +20,7 @@ module Mergent
 
       case response
       when Net::HTTPSuccess
-        JSON.parse(response.read_body, object_class: Mergent::Object)
+        JSON.parse(response.read_body)
       else
         begin
           body = JSON.parse(response.read_body)

--- a/lib/mergent/object.rb
+++ b/lib/mergent/object.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
 module Mergent
-  class Object < OpenStruct; end # rubocop:disable Style/OpenStructUse
+  class Object
+    def initialize(data = {})
+      @_data = data.transform_keys(&:to_sym)
+    end
+
+    def [](key)
+      @_data[key.to_sym]
+    end
+
+    def []=(key, value)
+      @_data[key.to_sym] = value
+    end
+
+    def method_missing(name, *args)
+      return super unless @_data.key?(name)
+
+      @_data[name]
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      @_data.key?(name) || super
+    end
+  end
 end

--- a/lib/mergent/task.rb
+++ b/lib/mergent/task.rb
@@ -6,14 +6,8 @@ require_relative "object"
 module Mergent
   class Task < Mergent::Object
     def self.create(params = {})
-      object = Client.post("tasks", params)
-      new(object)
-    end
-
-    %i[name description status request scheduled_for delay].each do |name|
-      define_method(name) do
-        self[name]
-      end
+      data = Client.post("tasks", params)
+      new(data)
     end
   end
 end

--- a/spec/mergent/client_spec.rb
+++ b/spec/mergent/client_spec.rb
@@ -16,11 +16,10 @@ RSpec.describe Mergent::Client do
              )
              .to_return(body: params.to_json)
 
-      object = described_class.post(:objects, params)
+      json = described_class.post(:objects, params)
 
       expect(stub).to have_been_made
-      expect(object).to be_a Mergent::Object
-      expect(object.name).to eq "objectname"
+      expect(json["name"]).to eq "objectname"
     end
 
     context "when the API returns an error with a body" do

--- a/spec/mergent/object_spec.rb
+++ b/spec/mergent/object_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe Mergent::Object do
+  describe ".initialize" do
+    it "initializes an Object with the provided data" do
+      object = described_class.new({ foo: :bar })
+
+      expect(object.foo).to eq :bar
+    end
+
+    it "symbolizes the keys" do
+      object = described_class.new({ "foo" => :bar })
+
+      expect(object.foo).to eq :bar
+    end
+  end
+
+  describe "#[]" do
+    it "allows fields to be retreived using hash notation" do
+      object = described_class.new({ foo: :bar })
+
+      expect(object[:foo]).to eq :bar
+      expect(object["foo"]).to eq :bar
+    end
+  end
+
+  describe "#[]=" do
+    it "allows fields to be set using hash notation" do
+      object = described_class.new
+      object[:foo] = :bar
+
+      expect(object[:foo]).to eq :bar
+      expect(object["foo"]).to eq :bar
+    end
+  end
+
+  describe "#method_missing" do
+    it "allows fields to be retreived using method notation" do
+      object = described_class.new({ foo: :bar })
+
+      expect(object.foo).to eq :bar
+    end
+  end
+
+  describe "#respond_to?" do
+    it "returns true when the method exists" do
+      object = described_class.new
+      object[:foo] = :bar
+
+      expect(object.respond_to?(:foo)).to be true
+    end
+
+    it "returns false when the method does not exist" do
+      object = described_class.new
+
+      expect(object.respond_to?(:foo)).to be false
+    end
+  end
+end

--- a/spec/mergent/task_spec.rb
+++ b/spec/mergent/task_spec.rb
@@ -23,12 +23,4 @@ RSpec.describe Mergent::Task do
       expect(task.name).to eq "taskname"
     end
   end
-
-  describe "delegated methods" do
-    %i[name description status request scheduled_for delay].each do |method_name|
-      it "defines a method for #{method_name}" do
-        expect(described_class.new(method_name => :foo).public_send(method_name)).to(eq(:foo))
-      end
-    end
-  end
 end


### PR DESCRIPTION
Inspired by: https://ruby-doc.org/core-3.1.0/BasicObject.html & https://github.com/lostisland/sawyer/blob/master/lib/sawyer/resource.rb