### PR TITLE
Replace OpenStruct with Mergent::Object wrapped Hash

### DIFF
--- a/lib/mergent/client.rb
+++ b/lib/mergent/client.rb
@@ -20,7 +20,7 @@ module Mergent
 
       case response
       when Net::HTTPSuccess
-        JSON.parse(response.read_body, object_class: Mergent::Object)
+        JSON.parse(response.read_body)
       else
         begin
           body = JSON.parse(response.read_body)

--- a/lib/mergent/object.rb
+++ b/lib/mergent/object.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
 module Mergent
-  class Object < OpenStruct; end # rubocop:disable Style/OpenStructUse
+  class Object
+    attr_reader :_data
+
+    def initialize(data = {})
+      @_data = data.transform_keys(&:to_sym)
+    end
+  end
 end

--- a/lib/mergent/task.rb
+++ b/lib/mergent/task.rb
@@ -5,15 +5,17 @@ require_relative "object"
 
 module Mergent
   class Task < Mergent::Object
-    def self.create(params = {})
-      object = Client.post("tasks", params)
-      new(object)
+    ATTRS = %i[name description status request scheduled_for created_at].freeze
+
+    ATTRS.each do |name|
+      define_method(name) do
+        @_data[name]
+      end
     end
 
-    %i[name description status request scheduled_for delay].each do |name|
-      define_method(name) do
-        self[name]
-      end
+    def self.create(params = {})
+      data = Client.post("tasks", params)
+      new(data)
     end
   end
 end

--- a/spec/mergent/client_spec.rb
+++ b/spec/mergent/client_spec.rb
@@ -16,11 +16,10 @@ RSpec.describe Mergent::Client do
              )
              .to_return(body: params.to_json)
 
-      object = described_class.post(:objects, params)
+      data = described_class.post(:objects, params)
 
       expect(stub).to have_been_made
-      expect(object).to be_a Mergent::Object
-      expect(object.name).to eq "objectname"
+      expect(data["name"]).to eq "objectname"
     end
 
     context "when the API returns an error with a body" do

--- a/spec/mergent/task_spec.rb
+++ b/spec/mergent/task_spec.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Mergent::Task do
+  describe "delegated methods" do
+    described_class::ATTRS.each do |method_name|
+      it "defines a method for #{method_name}" do
+        expect(described_class.new({ method_name => :foo }).public_send(method_name)).to(eq(:foo))
+      end
+    end
+  end
+
   describe "#create" do
     it "creates and returns a Task with the specified params" do
       Mergent.api_key = "abcd1234"
@@ -21,14 +29,6 @@ RSpec.describe Mergent::Task do
       expect(stub).to have_been_made
       expect(task).to be_a described_class
       expect(task.name).to eq "taskname"
-    end
-  end
-
-  describe "delegated methods" do
-    %i[name description status request scheduled_for delay].each do |method_name|
-      it "defines a method for #{method_name}" do
-        expect(described_class.new(method_name => :foo).public_send(method_name)).to(eq(:foo))
-      end
     end
   end
 end


### PR DESCRIPTION
This is an alternative approach to #11 

Prior to this PR, when we used `OpenStruct`, calling `#foo` on any `Mergent::Object` subclass would return nil, whether or not it was defined.

This moves us away from `OpenStruct` so that calling `#foo` will raise `NoMethodError` (unless defined, of course).