### PR TITLE
Add RequestValidator

### DIFF
--- a/lib/mergent.rb
+++ b/lib/mergent.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "mergent/errors"
+require_relative "mergent/request_validator"
 require_relative "mergent/task"
 require_relative "mergent/version"
 

--- a/lib/mergent/request_validator.rb
+++ b/lib/mergent/request_validator.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Mergent
+  class RequestValidator
+    def initialize(api_key)
+      @api_key = api_key || Mergent.api_key
+    end
+
+    def build_signature_for(url, body)
+      data = (url || "") + (body || "")
+      digest = OpenSSL::Digest.new("sha1")
+      Base64.strict_encode64(OpenSSL::HMAC.digest(digest, @api_key, data))
+    end
+
+    def valid_signature?(url, body, signature)
+      build_signature_for(url, body) == signature
+    end
+  end
+end

--- a/spec/mergent/request_validator_spec.rb
+++ b/spec/mergent/request_validator_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Mergent::RequestValidator do
+  subject(:validator) { described_class.new("12345") }
+
+  describe "#build_signature_for" do
+    it "builds a HMAC-SHA1 signature for the provided url & body" do
+      url = "https://example.com/webhook"
+      body = "foo"
+
+      signature = validator.build_signature_for(url, body)
+
+      expect(signature).to(eq("HCAShLIZgdTK1ByO3LN7UywbjIQ="))
+    end
+
+    context "with nil params" do
+      it "is valid" do
+        signature = validator.build_signature_for(nil, nil)
+        expect(signature).to(eq("KT7FsM8VSFUliCTsf6xdxj0XaRU="))
+      end
+    end
+  end
+
+  describe "#valid_signature?" do
+    it "returns true when the signature is valid" do
+      signature = validator.build_signature_for(nil, nil)
+      expect(validator.valid_signature?(nil, nil, signature)).to(eq(true))
+    end
+
+    it "returns false when the signature is invalid" do
+      expect(validator.valid_signature?(nil, nil, "invalidsignature")).to(eq(false))
+    end
+  end
+end


### PR DESCRIPTION
Mergent signs all webhook requests to your application with an `X-Mergent-Signature` HTTP header. Mergent uses the URL and body sent in the Task request parameter your application supplied to Mergent to create this signature. The signature uses the HMAC-SHA1 hashing algorithm with your Mergent project's API key as the secret key.

This is the Ruby implementation for building & validating the signature.