### PR TITLE
Update to use API V2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+- Add `id` field to Task
+- Add `queue` field to Task, defaulting to `default`
+- Remove `description` field from Task
+
 ## [0.2.2] - 2022-01-20
 
 - Add `Mergent::RequestValidator` to validate that webhooks came from Mergent's API

--- a/lib/mergent.rb
+++ b/lib/mergent.rb
@@ -6,7 +6,7 @@ require_relative "mergent/task"
 require_relative "mergent/version"
 
 module Mergent
-  ENDPOINT = "https://api.mergent.co/v1"
+  ENDPOINT = "https://api.mergent.co/v2"
 
   class << self
     attr_accessor :api_key, :endpoint

--- a/lib/mergent/task.rb
+++ b/lib/mergent/task.rb
@@ -6,7 +6,7 @@ require_relative "object"
 module Mergent
   class Task < Mergent::Object
     DEFAULT_QUEUE = "default"
-    ATTRS = %i[queue status request scheduled_for created_at].freeze
+    ATTRS = %i[id queue status request scheduled_for created_at].freeze
 
     ATTRS.each do |name|
       define_method(name) do

--- a/lib/mergent/task.rb
+++ b/lib/mergent/task.rb
@@ -6,7 +6,7 @@ require_relative "object"
 module Mergent
   class Task < Mergent::Object
     DEFAULT_QUEUE = "default"
-    ATTRS = %i[id queue status request scheduled_for created_at].freeze
+    ATTRS = %i[id name queue status request scheduled_for created_at].freeze
 
     ATTRS.each do |name|
       define_method(name) do

--- a/lib/mergent/task.rb
+++ b/lib/mergent/task.rb
@@ -5,7 +5,8 @@ require_relative "object"
 
 module Mergent
   class Task < Mergent::Object
-    ATTRS = %i[name description status request scheduled_for created_at].freeze
+    DEFAULT_QUEUE = "default"
+    ATTRS = %i[queue status request scheduled_for created_at].freeze
 
     ATTRS.each do |name|
       define_method(name) do
@@ -14,7 +15,10 @@ module Mergent
     end
 
     def self.create(params = {})
-      data = Client.post("tasks", params)
+      data = Client.post(
+        "tasks",
+        { queue: DEFAULT_QUEUE }.merge(params)
+      )
       new(data)
     end
   end

--- a/spec/mergent/task_spec.rb
+++ b/spec/mergent/task_spec.rb
@@ -10,25 +10,50 @@ RSpec.describe Mergent::Task do
   end
 
   describe "#create" do
-    it "creates and returns a Task with the specified params" do
+    before do
       Mergent.api_key = "abcd1234"
+    end
 
-      params = { request: { url: "https://example.com" } }
-      stub = stub_request(:post, "#{Mergent.endpoint}/tasks")
-             .with(
-               headers: {
-                 Authorization: "Bearer #{Mergent.api_key}",
-                 "Content-Type": "application/json"
-               },
-               body: params.to_json
-             )
-             .to_return(body: { name: "taskname" }.to_json)
+    let!(:stub) do
+      stub_request(:post, "#{Mergent.endpoint}/tasks")
+        .with(
+          headers: {
+            Authorization: "Bearer #{Mergent.api_key}",
+            "Content-Type": "application/json"
+          },
+          body: expected_body
+        )
+        .to_return(body: { id: "3ffd61d6-b10e-45d5-b266-e998aea71e8b", queue: queue }.to_json)
+    end
 
-      task = described_class.create(params)
+    context "when queue is passed" do
+      let(:params) { { queue: queue, request: { url: "https://example.com" } } }
+      let(:queue) { "foobar" }
 
-      expect(stub).to have_been_made
-      expect(task).to be_a described_class
-      expect(task.name).to eq "taskname"
+      let(:expected_body) { params.to_json }
+
+      it "creates and returns a Task with the specified params" do
+        task = described_class.create(params)
+
+        expect(stub).to have_been_made
+        expect(task).to be_a described_class
+        expect(task.queue).to eq queue
+      end
+    end
+
+    context "when :queue is not passed" do
+      let(:params) { { request: { url: "https://example.com" } } }
+
+      let(:expected_body) { { queue: queue }.merge(params).to_json }
+      let(:queue) { "default" }
+
+      it "uses the default queue name" do
+        task = described_class.create(params)
+
+        expect(stub).to have_been_made
+        expect(task).to be_a described_class
+        expect(task.queue).to eq "default"
+      end
     end
   end
 end


### PR DESCRIPTION
* Remove ~`name` and~ `description` attributes (no longer supported)
* Add `queue` attribute (optional, defaulting to "default")
* add `id` attribute
