### PR TITLE
if a response returns a 204, handle the `nil`

### DIFF
--- a/lib/mergent/client.rb
+++ b/lib/mergent/client.rb
@@ -33,7 +33,7 @@ module Mergent
       response = https.request(request)
 
       read_body = response.read_body
-      response_body = read_body.empty? ? "{}" : read_body
+      response_body = read_body.nil? || read_body.empty? ? "{}" : read_body
 
       case response
       when Net::HTTPSuccess

--- a/spec/mergent/client_spec.rb
+++ b/spec/mergent/client_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe Mergent::Client do
       expect(data["name"]).to eq "objectname"
     end
 
+    context "when the API returns a successful response without a body" do
+      it "returns an empty hash" do
+        stub_request(action, "#{Mergent.endpoint}/objects")
+          .to_return(
+            status: 204,
+            body: nil
+          )
+
+        data = described_class.public_send(action, :objects, {})
+        expect(data).to(eq({}))
+      end
+    end
+
     context "when the API returns an error with a body, without additional errors" do
       it "raises an Error" do
         stub_request(action, "#{Mergent.endpoint}/objects")


### PR DESCRIPTION
read_body on a 200 response with an empty body will return an empty string, but will return nil on a 204 response (which we return for deletes)

handle those correctly.